### PR TITLE
Add spec to prove subclass with an argument specified has borken help

### DIFF
--- a/spec/fixtures/subcommand.thor
+++ b/spec/fixtures/subcommand.thor
@@ -7,8 +7,21 @@ module TestSubcommands
     end
   end
 
+  class SubcommandWithArgument < Thor
+    argument :arg, type: :string
+
+    desc "print_arg", "My method with a cool argument"
+    def print_arg
+      print "cool feature\n"
+    end
+  end
+
   class Parent < Thor
     class_option "opt"
+
+
+    desc "arg", "My subcommand with argument"
+    subcommand "with_arg", SubcommandWithArgument
 
     desc "sub", "My subcommand"
     subcommand "sub", Subcommand

--- a/spec/subcommand_spec.rb
+++ b/spec/subcommand_spec.rb
@@ -43,6 +43,13 @@ describe Thor do
       sub_help = capture(:stdout) { TestSubcommands::Parent.start(%w[help sub])}
       expect(output).to eq(sub_help)
     end
+
+    context 'when a subcommand as an argument defined' do
+      it "the specific subcommand help should be displayed" do
+        output = capture(:stdout) { TestSubcommands::Parent.start(%w[with_arg help print_arg])}
+        expect(output).to include("Usage:")
+      end
+    end
   end
 
 end


### PR DESCRIPTION
When running this following i was expecting to see the print_arg full help section:

``` shell
thor subcommand_with_argument help print_arg
```

instead i see the subcommand general help:

``` shell
Commands:
       thor subcommand_with_argument help ARG [COMMAND]  # Describe subcommands or one specific subcommand
       thor subcommand_with_argument print_arg ARG       # My method with a cool argument
```

if i remove the argument in the subclass (i.e comment out this line https://github.com/StupidCodeFactory/thor/pull/1/files#diff-a113f9bffbf7327e2f860433311b4e15R11) then it does show the print_arg full help section
